### PR TITLE
Fix nil GetSpellInfo when addon loads

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1,4 +1,5 @@
 ﻿local _, ns = ...
+local GetSpellInfo = _G.GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo)
 
 FastFilgerDB = FastFilgerDB or {}
 local class = select(2, UnitClass("player"))

--- a/Lib.lua
+++ b/Lib.lua
@@ -1,4 +1,5 @@
 ﻿local addon, ns = ...
+local GetSpellInfo = _G.GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo)
 local Filger = {}
 local Filger_Spells = Filger_Spells or {}
 local MyUnits = {player = true, vehicle = true, pet = true}


### PR DESCRIPTION
## Summary
- ensure `GetSpellInfo` is resolved from the global table (or via `C_Spell`) in `Core.lua` and `Lib.lua`

## Testing
- `luac` **failed**: command not found
- `lua` **failed**: command not found

------
https://chatgpt.com/codex/tasks/task_e_687aefc82a9c832e93555e033c06800d