### PR TITLE
Fix nil spellname error in DisplayActives

### DIFF
--- a/Lib.lua
+++ b/Lib.lua
@@ -280,7 +280,16 @@ function Filger:DisplayActives()
     for activeIndex, value in pairs(temp) do
         local bar = self.bars[index]
         bar.spellName = GetSpellInfo(value.spid)
-        if self.Mode == "BAR" and bar.spellname then
+        if self.Mode == "BAR" then
+            if not bar.spellname then
+                local barHeight = floor(self.IconSize * 0.33)
+                bar.spellname = bar.statusbar:CreateFontString("$parentSpellName", "OVERLAY")
+                bar.spellname:SetFont(GameTooltipText:GetFont(), Misc.barNameSize, "OUTLINE")
+                bar.spellname:SetShadowOffset(1 * Misc.mult, -1 * Misc.mult)
+                bar.spellname:SetPoint("BOTTOMLEFT", bar.statusbar, 0, barHeight-1)
+                bar.spellname:SetPoint("RIGHT", bar.time, "LEFT")
+                bar.spellname:SetJustifyH("LEFT")
+            end
             bar.spellname:SetText(bar.spellName or "")
         end
         bar.icon:SetTexture(value.icon)


### PR DESCRIPTION
## Summary
- handle missing `spellname` field when showing bars

## Testing
- `luac` was not available so skipped syntax checks

------
https://chatgpt.com/codex/tasks/task_e_687af27d046c832eb67b1fd1c5b1cc79