### PR TITLE
Fix SetText error in DisplayActives

### DIFF
--- a/Lib.lua
+++ b/Lib.lua
@@ -290,7 +290,7 @@ function Filger:DisplayActives()
                 bar.spellname:SetPoint("RIGHT", bar.time, "LEFT")
                 bar.spellname:SetJustifyH("LEFT")
             end
-            if bar.spellname and bar.spellname.SetText then
+            if bar.spellname and type(bar.spellname.SetText) == "function" then
                 bar.spellname:SetText(bar.spellName or "")
             end
         end

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ WOW Buff/Debuff filter, based on combat log, nothing but fast!!!
 `/ff test `
 
 `/ff reset`
+


### PR DESCRIPTION
## Summary
- improve safety before setting spell name text
- add newline in README

## Testing
- `luac -p Lib.lua && luac -p Core.lua && luac -p Style.lua && luac -p Spells.lua && luac -p PVPSpells.lua` *(fails: `luac` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfcaf3324832e8242711f9880beec