### PR TITLE
Fix GetSpellCooldown nil error

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1,5 +1,6 @@
 ﻿local _, ns = ...
 local GetSpellInfo = _G.GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo)
+local GetSpellCooldown = _G.GetSpellCooldown or (C_Spell and C_Spell.GetSpellCooldown)
 
 FastFilgerDB = FastFilgerDB or {}
 local class = select(2, UnitClass("player"))

--- a/Lib.lua
+++ b/Lib.lua
@@ -1,5 +1,6 @@
 ﻿local addon, ns = ...
 local GetSpellInfo = _G.GetSpellInfo or (C_Spell and C_Spell.GetSpellInfo)
+local GetSpellCooldown = _G.GetSpellCooldown or (C_Spell and C_Spell.GetSpellCooldown)
 local Filger = {}
 local Filger_Spells = Filger_Spells or {}
 local MyUnits = {player = true, vehicle = true, pet = true}


### PR DESCRIPTION
## Summary
- define `GetSpellCooldown` using the updated API in both Core.lua and Lib.lua

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c0bd97d14832e8e865d739193a3a6